### PR TITLE
Allow for...of and for...in statements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,21 @@ module.exports = {
     'no-duplicate-imports': 'off',
 
     'no-plusplus': 'off',
+
+    // Override the base rule to remove 'ForInStatement' and 'ForOfStatement'
+    // from restrictions.
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'LabeledStatement',
+        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
+
     'no-underscore-dangle': 'off',
 
     'object-curly-newline': 'off',


### PR DESCRIPTION
Fixes #45 

I've been adding more `for...of` statements to my code, and have had to add eslint exclusion comments each time, so I think it's about time we did this officially.