### PR TITLE
Disable camelcase rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ module.exports = {
     // Airbnb enforces this but we use this feature a lot!
     'react/jsx-props-no-spreading': 'off',
 
-    // Disable camelcase rule. 
+    // Disable camelcase rule.
     '@typescript-eslint/camelcase': ['off'],
   },
 };

--- a/index.js
+++ b/index.js
@@ -205,5 +205,8 @@ module.exports = {
 
     // Airbnb enforces this but we use this feature a lot!
     'react/jsx-props-no-spreading': 'off',
+
+    // Disable camelcase rule. 
+    "@typescript-eslint/camelcase": ["off"]
   },
 };

--- a/index.js
+++ b/index.js
@@ -207,6 +207,6 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
 
     // Disable camelcase rule. 
-    "@typescript-eslint/camelcase": ["off"]
+    '@typescript-eslint/camelcase': ['off'],
   },
 };


### PR DESCRIPTION
Fixes #220 

Note that ideally we wouldn't use this rule, as it's deprecated, but we need it to override the same rule from [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.json#L8), which we utilize in our typescript projects.