### PR TITLE
Use Node 14 and 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ references:
     working_directory: ~/eslint-config-amo
     docker:
       # This is the NodeJS version we run in production.
-      - image: circleci/node:12
+      - image: circleci/node:14
 
   defaults-next: &defaults-next
     working_directory: ~/eslint-config-amo
     docker:
       # This is the next NodeJS version we will support.
-      - image: circleci/node:14
+      - image: circleci/node:16
 
   restore_build_cache: &restore_build_cache
     restore_cache:


### PR DESCRIPTION
Use Node 14 as default version, Node 16 as next, to be consistent across our projects.