### PR TITLE
Split config into a base config and the (old) config, which includes base + airbnb (full) and React rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.tgz
 node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+*.tgz
+.*
+CODE_OF_CONDUCT.md
+renovate.json
+tests/

--- a/base.js
+++ b/base.js
@@ -1,0 +1,184 @@
+module.exports = {
+  extends: [
+    'airbnb-base',
+    'plugin:prettier/recommended',
+    'plugin:jest/recommended',
+  ],
+  rules: {
+    'arrow-body-style': 'off',
+    'arrow-parens': ['error', 'always'],
+
+    // Beware about turning this rule back on. The rule encourages you to
+    // create static class methods on React components when they don't use
+    // `this`.  However, it will not warn you if you access `this` in a static
+    // method accidentally (which would most likely be a mistake).
+    'class-methods-use-this': 'off',
+
+    'comma-dangle': [
+      'error',
+      {
+        arrays: 'always-multiline',
+        objects: 'always-multiline',
+        imports: 'always-multiline',
+        exports: 'always-multiline',
+        functions: 'ignore',
+      },
+    ],
+
+    // Turn off function paren newline.
+    'function-paren-newline': 'off',
+
+    // This makes sure imported modules exist.
+    'import/no-unresolved': ['error'],
+
+    // This makes sure imported names exist.
+    'import/named': ['error'],
+
+    // This will catch accidental default imports when no default is defined.
+    'import/default': ['error'],
+
+    // This makes sure `*' imports are dereferenced to real exports.
+    'import/namespace': ['error'],
+
+    // This catches any export mistakes.
+    'import/export': ['error'],
+
+    // This catches default names that conflict with actual exported names.
+    // For example, this was probably a typo:
+    //   import foo from 'bar';
+    // that should be corrected as:
+    //   import { foo } from 'bar';
+    'import/no-named-as-default': ['error'],
+
+    // This catches possible typos like trying to access a real export on a
+    // default import.
+    'import/no-named-as-default-member': ['error'],
+
+    // This prevents exporting a mutable variable.
+    'import/no-mutable-exports': ['error'],
+
+    // This makes sure package.json defines dev vs. prod dependencies correctly.
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        // The following are not allowed to be imported. See .eslintrc in other
+        // directories (like ./test) for where this gets overidden.
+        devDependencies: false,
+        optionalDependencies: false,
+        peerDependencies: false,
+      },
+    ],
+
+    // This ensures imports are at the top of the file.
+    'import/imports-first': ['error'],
+
+    // This reports when you accidentally import/export an object twice.
+    'import/no-duplicates': ['error'],
+
+    // This ensures import statements never provide a file extension in the path.
+    'import/extensions': ['error', 'never'],
+
+    // This ensures imports are organized by type and that groups are separated
+    // by a new line.
+    'import/order': [
+      'error',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          ['parent', 'sibling'],
+          'index',
+        ],
+        'newlines-between': 'always',
+      },
+    ],
+
+    // Turn of the preference to have a default export.
+    'import/prefer-default-export': ['off'],
+
+    // This ensures a new line after all import statements.
+    'import/newline-after-import': ['error'],
+
+    // Add jest specific eslint rules.
+    'jest/no-disabled-tests': 'error',
+    'jest/no-focused-tests': 'error',
+    'jest/no-identical-title': 'error',
+    'jest/valid-expect': 'error',
+    'jest/valid-title': [
+      'error',
+      {
+        ignoreTypeOfDescribeName: true,
+      },
+    ],
+
+    // We do not want to enforce this rule, which we inherit.
+    // Awaits in loops can be acceptable.
+    'no-await-in-loop': 'off',
+
+    // Generally avoid the use of console.
+    'no-console': 'error',
+
+    // We use import/no-duplicates instead because it supports Flow types.
+    'no-duplicate-imports': 'off',
+
+    // Airbnb sets `allowElseIf` to false but we do not want that.
+    'no-else-return': 'error',
+
+    'no-plusplus': 'off',
+
+    // Override the base rule to remove 'ForInStatement' and 'ForOfStatement'
+    // from restrictions.
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'LabeledStatement',
+        message:
+          'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message:
+          '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
+
+    'no-underscore-dangle': 'off',
+
+    'object-curly-newline': 'off',
+
+    // Prefer destructuring from arrays and objects
+    // https://eslint.org/docs/rules/prefer-destructuring
+    // We turn this off for assignments.
+    'prefer-destructuring': [
+      'error',
+      {
+        VariableDeclarator: {
+          array: false,
+          object: true,
+        },
+        AssignmentExpression: {
+          array: false,
+          object: false,
+        },
+      },
+      {
+        enforceForRenamedProperties: false,
+      },
+    ],
+
+    // Specify whether double or single quotes should be used. Allows template
+    // literals.
+    quotes: [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: true },
+    ],
+
+    // Semi-colons should always be at the end of statements.
+    'semi-style': ['error', 'last'],
+
+    // Disable camelcase rule
+    camelcase: 'off',
+  },
+};

--- a/index.js
+++ b/index.js
@@ -1,113 +1,7 @@
 module.exports = {
-  extends: ['airbnb', 'plugin:prettier/recommended', 'plugin:jest/recommended'],
+  // Use `airbnb`, which includes `airbnb:base` and the React-related configs.
+  extends: ['airbnb', 'amo/base'],
   rules: {
-    'arrow-body-style': 'off',
-    'arrow-parens': ['error', 'always'],
-
-    // Beware about turning this rule back on. The rule encourages you to create
-    // static class methods on React components when they don't use `this`.
-    // However, it will not warn you if you access `this` in a static method
-    // accidentally (which would most likely be a mistake).
-    'class-methods-use-this': 'off',
-
-    'comma-dangle': [
-      'error',
-      {
-        arrays: 'always-multiline',
-        objects: 'always-multiline',
-        imports: 'always-multiline',
-        exports: 'always-multiline',
-        functions: 'ignore',
-      },
-    ],
-
-    // Turn off function paren newline.
-    'function-paren-newline': 'off',
-
-    // This makes sure imported modules exist.
-    'import/no-unresolved': ['error'],
-
-    // This makes sure imported names exist.
-    'import/named': ['error'],
-
-    // This will catch accidental default imports when no default is defined.
-    'import/default': ['error'],
-
-    // This makes sure `*' imports are dereferenced to real exports.
-    'import/namespace': ['error'],
-
-    // This catches any export mistakes.
-    'import/export': ['error'],
-
-    // This catches default names that conflict with actual exported names.
-    // For example, this was probably a typo:
-    //   import foo from 'bar';
-    // that should be corrected as:
-    //   import { foo } from 'bar';
-    'import/no-named-as-default': ['error'],
-
-    // This catches possible typos like trying to access a real export on a
-    // default import.
-    'import/no-named-as-default-member': ['error'],
-
-    // This prevents exporting a mutable variable.
-    'import/no-mutable-exports': ['error'],
-
-    // This makes sure package.json defines dev vs. prod dependencies correctly.
-    'import/no-extraneous-dependencies': [
-      'error',
-      {
-        // The following are not allowed to be imported. See .eslintrc in other
-        // directories (like ./test) for where this gets overidden.
-        devDependencies: false,
-        optionalDependencies: false,
-        peerDependencies: false,
-      },
-    ],
-
-    // This ensures imports are at the top of the file.
-    'import/imports-first': ['error'],
-
-    // This reports when you accidentally import/export an object twice.
-    'import/no-duplicates': ['error'],
-
-    // This ensures import statements never provide a file extension in the path.
-    'import/extensions': ['error', 'never'],
-
-    // This ensures imports are organized by type and that groups are separated
-    // by a new line.
-    'import/order': [
-      'error',
-      {
-        groups: [
-          'builtin',
-          'external',
-          'internal',
-          ['parent', 'sibling'],
-          'index',
-        ],
-        'newlines-between': 'always',
-      },
-    ],
-
-    // Turn of the preference to have a default export.
-    'import/prefer-default-export': ['off'],
-
-    // This ensures a new line after all import statements.
-    'import/newline-after-import': ['error'],
-
-    // Add jest specific eslint rules.
-    'jest/no-disabled-tests': 'error',
-    'jest/no-focused-tests': 'error',
-    'jest/no-identical-title': 'error',
-    'jest/valid-expect': 'error',
-    'jest/valid-title': [
-      'error',
-      {
-        ignoreTypeOfDescribeName: true,
-      },
-    ],
-
     // Turn down warnings for our custom Link component.
     'jsx-a11y/anchor-is-valid': [
       'error',
@@ -129,71 +23,6 @@ module.exports = {
         allowChildren: false,
       },
     ],
-
-    // We do not want to enforce this rule, which we inherit.
-    // Awaits in loops can be acceptable.
-    'no-await-in-loop': 'off',
-
-    // Generally avoid the use of console.
-    'no-console': 'error',
-
-    // We use import/no-duplicates instead because it supports Flow types.
-    'no-duplicate-imports': 'off',
-
-    // Airbnb sets `allowElseIf` to false but we do not want that.
-    'no-else-return': 'error',
-
-    'no-plusplus': 'off',
-
-    // Override the base rule to remove 'ForInStatement' and 'ForOfStatement'
-    // from restrictions.
-    'no-restricted-syntax': [
-      'error',
-      {
-        selector: 'LabeledStatement',
-        message:
-          'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
-      },
-      {
-        selector: 'WithStatement',
-        message:
-          '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
-      },
-    ],
-
-    'no-underscore-dangle': 'off',
-
-    'object-curly-newline': 'off',
-
-    // Prefer destructuring from arrays and objects
-    // https://eslint.org/docs/rules/prefer-destructuring
-    // We turn this off for assignments.
-    'prefer-destructuring': [
-      'error',
-      {
-        VariableDeclarator: {
-          array: false,
-          object: true,
-        },
-        AssignmentExpression: {
-          array: false,
-          object: false,
-        },
-      },
-      {
-        enforceForRenamedProperties: false,
-      },
-    ],
-
-    // specify whether double or single quotes should be used. Allows template literals.
-    quotes: [
-      'error',
-      'single',
-      { avoidEscape: true, allowTemplateLiterals: true },
-    ],
-
-    // semi-colons should always be at the end of statements.
-    'semi-style': ['error', 'last'],
 
     // Airbnb has turned this rule on again but we don't want that yet.
     'react/destructuring-assignment': ['off', 'always'],
@@ -235,8 +64,5 @@ module.exports = {
 
     // Airbnb enforces this but we use this feature a lot!
     'react/jsx-props-no-spreading': 'off',
-
-    // Disable camelcase rule
-    camelcase: 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Eslint config for amo based projects",
   "main": "index.js",
   "scripts": {
-    "test": "node tests/test.js"
+    "test": "node tests/index.test.js"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "eslint-config-airbnb": "18.2.1",
+    "eslint-config-airbnb-base": "14.2.1",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.25.2",
     "eslint-plugin-jest": "25.2.2",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,14 +3,25 @@ const assert = require('assert');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { ESLint } = require('eslint');
 
+const mainConfig = require('../index');
+
 (async function tests() {
-  const input = ['index.js', 'tests/test.js'];
+  const input = ['base.js', 'index.js', 'tests/index.test.js'];
 
   const eslint = new ESLint({
     overrideConfig: {
+      ...mainConfig,
+      extends: mainConfig.extends.map((entry) => {
+        // We cannot load the `amo` config from here so we have to adjust the
+        // patch in `extends`.
+        if (entry === 'amo/base') {
+          return './base';
+        }
+
+        return entry;
+      }),
       env: { es6: true, node: true },
     },
-    overrideConfigFile: 'index.js',
     useEslintrc: false,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,9 +1118,9 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
     safe-buffer "~5.1.1"
 
 core-js-pure@^3.16.0:
-  version "3.18.3"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.18.3.tgz#7eed77dcce1445ab68fd68715856633e2fb3b90c"
-  integrity sha512-qfskyO/KjtbYn09bn1IPkuhHl5PlJ6IzJ9s9sraJ1EqcuGyLGKzhSM1cY0zgyL9hx42eulQLZ6WaeK5ycJCkqw==
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.0.tgz#db6fdadfdd4dc280ec93b64c3c2e8460e6f10094"
+  integrity sha512-UEQk8AxyCYvNAs6baNoPqDADv7BX0AmBLGxVsrAifPPx/C8EAzV4Q+2ZUJqVzfI2TQQEZITnwUkWcHpgc/IubQ==
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -1347,7 +1347,7 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-airbnb-base@^14.2.1:
+eslint-config-airbnb-base@14.2.1, eslint-config-airbnb-base@^14.2.1:
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz#8a2eb38455dc5a312550193b319cdaeef042cd1e"
   integrity sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==


### PR DESCRIPTION
This PR adds a new `base.js` configuration file that is used by the existing `index.js` file, which is our main configuration file. The `base` config uses `airbnb-base`, which allows us to not load the React-related configs.