### PR TITLE
Remove airbnb configs

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,12 +1,22 @@
 module.exports = {
   extends: [
-    'airbnb-base',
-    'plugin:prettier/recommended',
+    'eslint:recommended',
+    'plugin:import/recommended',
     'plugin:jest/recommended',
+    'plugin:prettier/recommended',
   ],
   rules: {
+    // Enforces return statements in callbacks of array's methods
+    'array-callback-return': ['error', { allowImplicit: true }],
+
     'arrow-body-style': 'off',
     'arrow-parens': ['error', 'always'],
+
+    // Treat var statements as if they were block scoped
+    'block-scoped-var': 'error',
+
+    // Disable camelcase rule
+    camelcase: 'off',
 
     // Beware about turning this rule back on. The rule encourages you to
     // create static class methods on React components when they don't use
@@ -25,8 +35,45 @@ module.exports = {
       },
     ],
 
+    // Require return statements to either always or never specify values
+    'consistent-return': 'error',
+
+    // Require default case in switch statements
+    'default-case': ['error', { commentPattern: '^no default$' }],
+
+    // Enforce default clauses in switch statements to be last
+    'default-case-last': 'error',
+
+    'default-param-last': 'error',
+
+    // Encourage use of dot notation whenever possible
+    'dot-notation': ['error', { allowKeywords: true }],
+
+    // require the use of === and !==
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
+
     // Turn off function paren newline.
     'function-paren-newline': 'off',
+
+    // Require function expressions to have a name
+    'func-names': 'warn',
+
+    // Require all requires be top-level
+    // TODO: This rule is deprecated and scheduled for removal in ESLint v11.
+    'global-require': 'error',
+
+    // Require grouped accessor pairs in object literals and classes
+    'grouped-accessor-pairs': 'error',
+
+    // Make sure for-in loops have an if statement
+    'guard-for-in': 'error',
+
+    // Disallow the use of Boolean literals in conditional expressions
+    // Also, prefer `a || b` over `a ? a : b`
+    'no-unneeded-ternary': ['error', { defaultAssignment: false }],
+
+    // Disallow usage of expressions in statement position
+    'no-unused-expressions': ['error'],
 
     // This makes sure imported modules exist.
     'import/no-unresolved': ['error'],
@@ -112,20 +159,242 @@ module.exports = {
       },
     ],
 
+    // Require or disallow newlines around directives
+    // TODO: This rule is deprecated and scheduled for removal in ESLint v11.
+    'lines-around-directive': [
+      'error',
+      {
+        before: 'always',
+        after: 'always',
+      },
+    ],
+
+    // Require or disallow an empty line between class members
+    // TODO: This rule is deprecated and scheduled for removal in ESLint v11.
+    'lines-between-class-members': [
+      'error',
+      'always',
+      { exceptAfterSingleLine: false },
+    ],
+
+    // Enforce a maximum number of classes per file
+    'max-classes-per-file': ['error', 1],
+
+    // Require a capital letter for constructors
+    'new-cap': [
+      'error',
+      {
+        newIsCap: true,
+        newIsCapExceptions: [],
+        capIsNew: false,
+        capIsNewExceptions: [
+          'Immutable.Map',
+          'Immutable.Set',
+          'Immutable.List',
+        ],
+      },
+    ],
+
+    // Disallow use of the Array constructor
+    'no-array-constructor': 'error',
+
     // We do not want to enforce this rule, which we inherit.
     // Awaits in loops can be acceptable.
     'no-await-in-loop': 'off',
 
+    // Disallow use of bitwise operators
+    'no-bitwise': 'error',
+
+    // Disallow use of the Buffer() constructor
+    // TODO: This rule is deprecated and scheduled for removal in ESLint v11.
+    'no-buffer-constructor': 'error',
+
+    // Disallow use of arguments.caller or arguments.callee
+    'no-caller': 'error',
+
     // Generally avoid the use of console.
     'no-console': 'error',
+
+    // Disallow returning value in constructor
+    'no-constructor-return': 'error',
+
+    // Disallow use of the continue statement
+    'no-continue': 'error',
 
     // We use import/no-duplicates instead because it supports Flow types.
     'no-duplicate-imports': 'off',
 
-    // Airbnb sets `allowElseIf` to false but we do not want that.
-    'no-else-return': 'error',
+    // Disallow else after a return in an if
+    'no-else-return': ['error', { allowElseIf: false }],
+
+    // Disallow use of eval()
+    'no-eval': 'error',
+
+    // Disallow adding to native types
+    'no-extend-native': 'error',
+
+    // Disallow unnecessary function binding
+    'no-extra-bind': 'error',
+
+    // Disallow Unnecessary Labels
+    'no-extra-label': 'error',
+
+    // disallow empty functions, except for standalone funcs/arrows
+    'no-empty-function': [
+      'error',
+      {
+        allow: ['arrowFunctions', 'functions', 'methods'],
+      },
+    ],
+
+    // Disallow use of eval()-like methods
+    'no-implied-eval': 'error',
+
+    // Disallow usage of __iterator__ property
+    'no-iterator': 'error',
+
+    // Disallow use of labels for anything other than loops and switches
+    'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
+
+    // Disallow labels that share a name with a variable
+    'no-label-var': 'error',
+
+    // Disallow unnecessary nested blocks
+    'no-lone-blocks': 'error',
+
+    // Disallow if as the only statement in an else block
+    'no-lonely-if': 'error',
+
+    // Disallow creation of functions within loops
+    'no-loop-func': 'error',
+
+    // Disallow use of chained assignment expressions
+    'no-multi-assign': ['error'],
+
+    // Disallow use of multiline strings
+    'no-multi-str': 'error',
+
+    // Disallow nested ternary expressions
+    'no-nested-ternary': 'error',
+
+    // Disallow use of new operator when not part of the assignment or comparison
+    'no-new': 'error',
+
+    // Disallow use of new operator for Function object
+    'no-new-func': 'error',
+
+    // Disallow use of the Object constructor
+    // TODO: This rule is deprecated, and we should be using
+    // `no-object-constructor` now.
+    'no-new-object': 'error',
+
+    // Disallow use of new operator with the require function
+    'no-new-require': 'error',
+
+    // Disallows creating new instances of String, Number, and Boolean
+    'no-new-wrappers': 'error',
+
+    // Disallow use of octal escape sequences in string literals, such as
+    // var foo = 'Copyright \251';
+    'no-octal-escape': 'error',
+
+    // Disallow reassignment of function parameters
+    // Disallow parameter object manipulation except for specific exclusions rule
+    'no-param-reassign': [
+      'error',
+      {
+        props: true,
+        ignorePropertyModificationsFor: [
+          'acc', // for reduce accumulators
+          'accumulator', // for reduce accumulators
+          'e', // for e.returnvalue
+          'ctx', // for Koa routing
+          'context', // for Koa routing
+          'req', // for Express requests
+          'request', // for Express requests
+          'res', // for Express responses
+          'response', // for Express responses
+          '$scope', // for Angular 1 scopes
+          'staticContext', // for ReactRouter context
+        ],
+      },
+    ],
+
+    // Disallow string concatenation with __dirname and __filename
+    // TODO: This rule is deprecated and scheduled for removal in ESLint v11.
+    'no-path-concat': 'error',
 
     'no-plusplus': 'off',
+
+    // Disallow returning values from Promise executor functions
+    'no-promise-executor-return': 'error',
+
+    // disallow usage of __proto__ property
+    'no-proto': 'error',
+
+    // Disallow specified names in exports
+    'no-restricted-exports': [
+      'error',
+      {
+        restrictedNamedExports: [
+          'default', // use `export default` to provide a default export
+          'then', // this will cause tons of confusion when your module is dynamically `import()`ed, and will break in most node ESM versions
+        ],
+      },
+    ],
+
+    // Disallow certain object properties
+    'no-restricted-properties': [
+      'error',
+      {
+        object: 'arguments',
+        property: 'callee',
+        message: 'arguments.callee is deprecated',
+      },
+      {
+        object: 'global',
+        property: 'isFinite',
+        message: 'Please use Number.isFinite instead',
+      },
+      {
+        object: 'self',
+        property: 'isFinite',
+        message: 'Please use Number.isFinite instead',
+      },
+      {
+        object: 'window',
+        property: 'isFinite',
+        message: 'Please use Number.isFinite instead',
+      },
+      {
+        object: 'global',
+        property: 'isNaN',
+        message: 'Please use Number.isNaN instead',
+      },
+      {
+        object: 'self',
+        property: 'isNaN',
+        message: 'Please use Number.isNaN instead',
+      },
+      {
+        object: 'window',
+        property: 'isNaN',
+        message: 'Please use Number.isNaN instead',
+      },
+      {
+        property: '__defineGetter__',
+        message: 'Please use Object.defineProperty instead.',
+      },
+      {
+        property: '__defineSetter__',
+        message: 'Please use Object.defineProperty instead.',
+      },
+      {
+        object: 'Math',
+        property: 'pow',
+        message: 'Use the exponentiation operator (**) instead.',
+      },
+    ],
 
     // Override the base rule to remove 'ForInStatement' and 'ForOfStatement'
     // from restrictions.
@@ -143,9 +412,103 @@ module.exports = {
       },
     ],
 
+    // Disallow use of assignment in return statement
+    'no-return-assign': ['error', 'always'],
+
+    // Disallow comparisons where both sides are exactly the same
+    'no-self-compare': 'error',
+
+    // Disallow use of comma operator
+    'no-sequences': 'error',
+
+    // Disallow use of `javascript:` urls
+    'no-script-url': 'error',
+
+    // Disallow declaration of variables already declared in the outer scope
+    'no-shadow': 'error',
+
+    // Disallow template literal placeholder syntax in regular strings
+    'no-template-curly-in-string': 'error',
+
+    // Restrict what can be thrown as an exception
+    'no-throw-literal': 'error',
+
+    // Disallow useless string concatenation
+    'no-useless-concat': 'error',
+
+    // Disallow redundant return; keywords
+    'no-useless-return': 'error',
+
+    // Disallow use of undefined when initializing variables
+    'no-undef-init': 'error',
+
     'no-underscore-dangle': 'off',
 
+    // Disallow loops with a body that allows only one iteration
+    'no-unreachable-loop': [
+      'error',
+      {
+        // See: https://eslint.org/docs/latest/rules/no-unreachable-loop#ignore
+        ignore: [],
+      },
+    ],
+
+    // Disallow use of variables before they are defined
+    'no-use-before-define': [
+      'error',
+      { functions: true, classes: true, variables: true },
+    ],
+
+    // require let or const instead of var
+    'no-var': 'error',
+
+    // Disallow use of void operator
+    'no-void': 'error',
+
+    // Disallow useless computed property keys
+    'no-useless-computed-key': 'error',
+
+    // Disallow unnecessary constructor
+    'no-useless-constructor': 'error',
+
+    // Disallow renaming import, export, and destructured assignments to the same name
+    'no-useless-rename': [
+      'error',
+      {
+        ignoreDestructuring: false,
+        ignoreImport: false,
+        ignoreExport: false,
+      },
+    ],
+
     'object-curly-newline': 'off',
+
+    // require method and property shorthand syntax for object literals
+    'object-shorthand': [
+      'error',
+      'always',
+      {
+        ignoreConstructors: false,
+        avoidQuotes: true,
+      },
+    ],
+
+    // Allow just one var statement per function
+    'one-var': ['error', 'never'],
+
+    // Require assignment operator shorthand where possible or prohibit it entirely
+    'operator-assignment': ['error', 'always'],
+
+    // suggest using of const declaration for variables that are never modified
+    // after declared
+    'prefer-const': [
+      'error',
+      {
+        destructuring: 'any',
+        // Avoid conflicts with the `no-use-before-define` rule.
+        ignoreReadBeforeAssign: true,
+      },
+    ],
 
     // Prefer destructuring from arrays and objects
     // https://eslint.org/docs/rules/prefer-destructuring
@@ -167,6 +530,61 @@ module.exports = {
       },
     ],
 
+    // Disallow the use of Math.pow in favor of the ** operator
+    'prefer-exponentiation-operator': 'error',
+
+    // Disallow parseInt() in favor of binary, octal, and hexadecimal literals
+    'prefer-numeric-literals': 'error',
+
+    // Prefer use of an object spread over Object.assign
+    'prefer-object-spread': 'error',
+
+    // Require using Error objects as Promise rejection reasons
+    'prefer-promise-reject-errors': ['error', { allowEmptyReject: true }],
+
+    // Use rest parameters instead of arguments
+    'prefer-rest-params': 'error',
+
+    'prefer-regex-literals': [
+      'error',
+      {
+        disallowRedundantWrapping: true,
+      },
+    ],
+
+    // Suggest using the spread syntax instead of .apply()
+    'prefer-spread': 'error',
+
+    // Suggest using template literals instead of string concatenation
+    'prefer-template': 'error',
+
+    // Require use of the second argument for parseInt()
+    radix: 'error',
+
+    // Require or disallow a space immediately following the // or /* in a comment
+    // TODO: This rule is deprecated and scheduled for removal in ESLint v11.
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        line: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', '/'], // space here to support sprockets directives, slash for TS /// comments
+        },
+        block: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
+          balanced: true,
+        },
+      },
+    ],
+
+    // Require a Symbol description
+    'symbol-description': 'error',
+
+    // Require or disallow the Unicode Byte Order Mark
+    'unicode-bom': ['error', 'never'],
+
     // Specify whether double or single quotes should be used. Allows template
     // literals.
     quotes: [
@@ -178,7 +596,10 @@ module.exports = {
     // Semi-colons should always be at the end of statements.
     'semi-style': ['error', 'last'],
 
-    // Disable camelcase rule
-    camelcase: 'off',
+    // Require to declare all vars on top of their containing scope
+    'vars-on-top': 'error',
+
+    // Require or disallow Yoda conditions
+    yoda: 'error',
   },
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 module.exports = {
-  // Use `airbnb`, which includes `airbnb:base` and the React-related configs.
-  extends: ['airbnb', 'amo/base'],
+  extends: [
+    'amo/base',
+    'plugin:jsx-a11y/recommended',
+    'plugin:react/recommended',
+  ],
   rules: {
     // Turn down warnings for our custom Link component.
     'jsx-a11y/anchor-is-valid': [
@@ -24,24 +27,9 @@ module.exports = {
       },
     ],
 
-    // Airbnb has turned this rule on again but we don't want that yet.
     'react/destructuring-assignment': ['off', 'always'],
-
-    // The airbnb default of this rule mainly encourages `shape` over `object`
-    // but there are too many bugs in the linter to use `shape` accurately.
     'react/forbid-prop-types': 'off',
 
-    'react/prefer-stateless-function': 'off',
-    'react/require-default-props': 'off',
-
-    // See: https://github.com/mozilla/eslint-config-amo/issues/63
-    'react/sort-comp': 'off',
-
-    // Use a 2 space indent for jsx props.
-    'react/jsx-indent-props': ['error', 2],
-
-    // Aligns closing brackets in jsx with the opening line.
-    'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
     'react/jsx-filename-extension': [
       'warn',
       {
@@ -49,20 +37,21 @@ module.exports = {
       },
     ],
 
-    // Allow more than one prop when the jsx is confined to a single line.
-    // Defaults to 1 prop per line when the jsx spans multiple lines.
-    'react/jsx-max-props-per-line': ['error', { when: 'multiline' }],
-
     // Make sure the first prop is on a new line for multiline props.
     'react/jsx-first-prop-new-line': ['error', 'multiline'],
+
     'react/jsx-key': 'error',
+    'react/jsx-props-no-spreading': 'off',
+
     'react/no-string-refs': 'error',
+    'react/prefer-stateless-function': 'off',
+    'react/require-default-props': 'off',
+
+    // See: https://github.com/mozilla/eslint-config-amo/issues/63
+    'react/sort-comp': 'off',
 
     // Enforces where React component static properties should be positioned.
     // We want them in the class body.
     'react/static-property-placement': ['error', 'static public field'],
-
-    // Airbnb enforces this but we use this feature a lot!
-    'react/jsx-props-no-spreading': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "author": "Mozilla Add-ons Team",
   "license": "MPL-2.0",
   "dependencies": {
-    "eslint-config-airbnb": "19.0.4",
-    "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jest": "29.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,11 +1709,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-confusing-browser-globals@^1.0.10:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
-  integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
-
 convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
@@ -2316,25 +2311,6 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
-eslint-config-airbnb-base@15.0.0, eslint-config-airbnb-base@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
-  integrity sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==
-  dependencies:
-    confusing-browser-globals "^1.0.10"
-    object.assign "^4.1.2"
-    object.entries "^1.1.5"
-    semver "^6.3.0"
-
-eslint-config-airbnb@19.0.4:
-  version "19.0.4"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz#84d4c3490ad70a0ffa571138ebcdea6ab085fdc3"
-  integrity sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==
-  dependencies:
-    eslint-config-airbnb-base "^15.0.0"
-    object.assign "^4.1.2"
-    object.entries "^1.1.5"
 
 eslint-config-prettier@10.1.8:
   version "10.1.8"
@@ -4106,7 +4082,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.2, object.assign@^4.1.4:
+object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
@@ -4138,7 +4114,7 @@ object.assign@^4.1.7:
     has-symbols "^1.1.0"
     object-keys "^1.1.1"
 
-object.entries@^1.1.5, object.entries@^1.1.9:
+object.entries@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.9.tgz#e4770a6a1444afb61bd39f984018b5bede25f8b3"
   integrity sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==


### PR DESCRIPTION
This PR removes the airbnb packages entierely but keeps the eslint configs as close as possible to what they were before (with the airbnb configs). 

I intend to release a new major version of this package and see if there are breakages in our repos (linter, frontend, etc.). But I think this is a good first step.

# `amo/base`

Below are the differences between the current config (named `eslint`) and the new one (in this PR, named `eslint-new`), generated with https://github.com/voxpelli/compare-eslint-configs.

## Only active in some:

* **eslint**
  * [import/first](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/first.md)
  * [import/no-absolute-path](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-absolute-path.md)
  * [import/no-amd](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-amd.md)
  * [import/no-cycle](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-cycle.md)
  * [import/no-dynamic-require](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-dynamic-require.md)
  * import/no-import-module-exports
  * [import/no-named-default](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-named-default.md)
  * [import/no-relative-packages](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-relative-packages.md)
  * [import/no-self-import](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-self-import.md)
  * [import/no-useless-path-segments](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-useless-path-segments.md)
  * [import/no-webpack-loader-syntax](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-webpack-loader-syntax.md)
  * [no-alert](https://eslint.org/docs/latest/rules/no-alert)
  * [no-restricted-globals](https://eslint.org/docs/latest/rules/no-restricted-globals)
  * [strict](https://eslint.org/docs/latest/rules/strict)

**Notes:**

- The `import/*` are now different because I switched to the recommended preset.
- `no-alert` was supposed to be [re-enabled](https://github.com/airbnb/javascript/blob/0e2ef178a26ba9ac3495402a182891ad8096d3a0/packages/eslint-config-airbnb-base/rules/best-practices.js#L70-L71) at some point so I decided to not backport this rule
- `no-restricted-globals` is overly complicated so I dropped it: https://github.com/airbnb/javascript/blob/0e2ef178a26ba9ac3495402a182891ad8096d3a0/packages/eslint-config-airbnb-base/rules/variables.js#L18-L34
- `strict` doesn't seem very useful

## Mixed severities:

* [**no-constant-condition**](https://eslint.org/docs/latest/rules/no-constant-condition)
  * _error_: eslint-new
  * _warn_: eslint

**Note:** I don't think I care that much since airbnb was emitting a warning but the recommended preset says it should be an error.

## Mixed configs where otherwise okay:

* [**getter-return**](https://eslint.org/docs/latest/rules/getter-return)
  * _eslint_:
    ```json
    [{"allowImplicit":true}]
    ```
* [**import/no-unresolved**](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-unresolved.md)
  * _eslint_:
    ```json
    [{"commonjs":true,"caseSensitive":true,"caseSensitiveStrict":false}]
    ```
* [**no-cond-assign**](https://eslint.org/docs/latest/rules/no-cond-assign)
  * _eslint_:
    ```json
    ["always"]
    ```
* [**no-global-assign**](https://eslint.org/docs/latest/rules/no-global-assign)
  * _eslint_:
    ```json
    [{"exceptions":[]}]
    ```
* [**no-self-assign**](https://eslint.org/docs/latest/rules/no-self-assign)
  * _eslint_:
    ```json
    [{"props":true}]
    ```
* [**no-unsafe-optional-chaining**](https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining)
  * _eslint_:
    ```json
    [{"disallowArithmeticOperators":true}]
    ```
* [**no-unused-vars**](https://eslint.org/docs/latest/rules/no-unused-vars)
  * _eslint_:
    ```json
    [{"vars":"all","args":"after-used","ignoreRestSiblings":true}]
    ```
* [**valid-typeof**](https://eslint.org/docs/latest/rules/valid-typeof)
  * _eslint_:
    ```json
    [{"requireStringLiterals":true}]
    ```

**Note:** Those rules are now using the recommended preset config instead of airbnb's config. I am fine with that.

# `amo`

Below are the differences between the current config (named `eslint`) and the new one (in this PR, named `eslint-new`):

## Only active in some:

* **eslint**
  * [jsx-a11y/control-has-associated-label](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/control-has-associated-label.md)
  * [jsx-a11y/lang](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/lang.md)
  * [react/button-has-type](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/button-has-type.md)
  * [react/default-props-match-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/default-props-match-prop-types.md)
  * [react/forbid-foreign-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/forbid-foreign-prop-types.md)
  * [react/function-component-definition](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/function-component-definition.md)
  * [react/jsx-boolean-value](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-boolean-value.md)
  * [react/jsx-closing-bracket-location](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-closing-bracket-location.md)
  * [react/jsx-curly-brace-presence](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-curly-brace-presence.md)
  * [react/jsx-fragments](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-fragments.md)
  * [react/jsx-indent-props](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-indent-props.md)
  * [react/jsx-max-props-per-line](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-max-props-per-line.md)
  * [react/jsx-no-bind](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-bind.md)
  * [react/jsx-no-constructed-context-values](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-constructed-context-values.md)
  * [react/jsx-no-script-url](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-script-url.md)
  * [react/jsx-no-useless-fragment](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-useless-fragment.md)
  * [react/jsx-pascal-case](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-pascal-case.md)
  * [react/no-access-state-in-setstate](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-access-state-in-setstate.md)
  * [react/no-array-index-key](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-array-index-key.md)
  * [react/no-arrow-function-lifecycle](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-arrow-function-lifecycle.md)
  * [react/no-danger](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-danger.md)
  * [react/no-did-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-did-update-set-state.md)
  * [react/no-invalid-html-attribute](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-invalid-html-attribute.md)
  * [react/no-namespace](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-namespace.md)
  * [react/no-redundant-should-component-update](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-redundant-should-component-update.md)
  * [react/no-this-in-sfc](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-this-in-sfc.md)
  * [react/no-typos](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-typos.md)
  * [react/no-unstable-nested-components](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unstable-nested-components.md)
  * [react/no-unused-class-component-methods](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unused-class-component-methods.md)
  * [react/no-unused-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unused-prop-types.md)
  * [react/no-unused-state](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unused-state.md)
  * [react/no-will-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-will-update-set-state.md)
  * [react/prefer-es6-class](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prefer-es6-class.md)
  * [react/prefer-exact-props](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prefer-exact-props.md)
  * [react/self-closing-comp](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/self-closing-comp.md)
  * [react/state-in-constructor](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/state-in-constructor.md)
  * [react/style-prop-object](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/style-prop-object.md)
  * [react/void-dom-elements-no-children](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/void-dom-elements-no-children.md)
* **eslint-new**
  * [jsx-a11y/autocomplete-valid](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/autocomplete-valid.md)
  * [react/display-name](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/display-name.md)
  * [react/no-direct-mutation-state](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-direct-mutation-state.md)

**Note:** I switched our config to the recommended react and jsx-a11y presets, hence why we have differences. In general, I think it's best to use recommended presets.

## Mixed configs where otherwise okay:

* [**jsx-a11y/alt-text**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/alt-text.md)
  * _eslint_:
    ```json
    [{"elements":["img","object","area","input[type=\"image\"]"],"img":[],"object":[],"area":[],"input[type=\"image\"]":[]}]
    ```
* [**jsx-a11y/anchor-has-content**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/anchor-has-content.md)
  * _eslint_:
    ```json
    [{"components":[]}]
    ```
* [**jsx-a11y/aria-role**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/aria-role.md)
  * _eslint_:
    ```json
    [{"ignoreNonDOM":false}]
    ```
* [**jsx-a11y/heading-has-content**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/heading-has-content.md)
  * _eslint_:
    ```json
    [{"components":[""]}]
    ```
* [**jsx-a11y/interactive-supports-focus**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/interactive-supports-focus.md)
  * _eslint-new_:
    ```json
    [{"tabbable":["button","checkbox","link","searchbox","spinbutton","switch","textbox"]}]
    ```
* [**jsx-a11y/label-has-associated-control**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/label-has-associated-control.md)
  * _eslint_:
    ```json
    [{"labelComponents":[],"labelAttributes":[],"controlComponents":[],"assert":"both","depth":25}]
    ```
* [**jsx-a11y/media-has-caption**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/media-has-caption.md)
  * _eslint_:
    ```json
    [{"audio":[],"video":[],"track":[]}]
    ```
* [**jsx-a11y/no-autofocus**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-autofocus.md)
  * _eslint_:
    ```json
    [{"ignoreNonDOM":true}]
    ```
* [**jsx-a11y/no-distracting-elements**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-distracting-elements.md)
  * _eslint_:
    ```json
    [{"elements":["marquee","blink"]}]
    ```
* [**jsx-a11y/no-interactive-element-to-noninteractive-role**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md)
  * _eslint_:
    ```json
    [{"tr":["none","presentation"]}]
    ```
  * _eslint-new_:
    ```json
    [{"tr":["none","presentation"],"canvas":["img"]}]
    ```
* [**jsx-a11y/no-noninteractive-element-interactions**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-noninteractive-element-interactions.md)
  * _eslint_:
    ```json
    [{"handlers":["onClick","onMouseDown","onMouseUp","onKeyPress","onKeyDown","onKeyUp"]}]
    ```
  * _eslint-new_:
    ```json
    [{"handlers":["onClick","onError","onLoad","onMouseDown","onMouseUp","onKeyPress","onKeyDown","onKeyUp"],"alert":["onKeyUp","onKeyDown","onKeyPress"],"body":["onError","onLoad"],"dialog":["onKeyUp","onKeyDown","onKeyPress"],"iframe":["onError","onLoad"],"img":["onError","onLoad"]}]
    ```
* [**jsx-a11y/no-noninteractive-element-to-interactive-role**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md)
  * _eslint_:
    ```json
    [{"ul":["listbox","menu","menubar","radiogroup","tablist","tree","treegrid"],"ol":["listbox","menu","menubar","radiogroup","tablist","tree","treegrid"],"li":["menuitem","option","row","tab","treeitem"],"table":["grid"],"td":["gridcell"]}]
    ```
  * _eslint-new_:
    ```json
    [{"ul":["listbox","menu","menubar","radiogroup","tablist","tree","treegrid"],"ol":["listbox","menu","menubar","radiogroup","tablist","tree","treegrid"],"li":["menuitem","menuitemradio","menuitemcheckbox","option","row","tab","treeitem"],"table":["grid"],"td":["gridcell"],"fieldset":["radiogroup","presentation"]}]
    ```
* [**jsx-a11y/no-noninteractive-tabindex**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-noninteractive-tabindex.md)
  * _eslint_:
    ```json
    [{"tags":[],"roles":["tabpanel"]}]
    ```
  * _eslint-new_:
    ```json
    [{"tags":[],"roles":["tabpanel"],"allowExpressionValues":true}]
    ```
* [**jsx-a11y/no-static-element-interactions**](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-static-element-interactions.md)
  * _eslint_:
    ```json
    [{"handlers":["onClick","onMouseDown","onMouseUp","onKeyPress","onKeyDown","onKeyUp"]}]
    ```
  * _eslint-new_:
    ```json
    [{"allowExpressionValues":true,"handlers":["onClick","onMouseDown","onMouseUp","onKeyPress","onKeyDown","onKeyUp"]}]
    ```
* [**react/jsx-no-duplicate-props**](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-duplicate-props.md)
  * _eslint_:
    ```json
    [{"ignoreCase":true}]
    ```
* [**react/jsx-no-target-blank**](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-target-blank.md)
  * _eslint_:
    ```json
    [{"enforceDynamicLinks":"always","links":true,"forms":false}]
    ```
* [**react/prop-types**](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prop-types.md)
  * _eslint_:
    ```json
    [{"ignore":[],"customValidators":[],"skipUndeclared":false}]
    ```

**Notes:** same as above.