### PR TITLE
Require typscript (dev dep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "devDependencies": {
     "eslint": "^8.0.0",
     "jest": "^30.0.0",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "typescript": "5.8.3"
   },
   "peerDependencies": {
     "eslint": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,6 +4984,11 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
+typescript@5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"


### PR DESCRIPTION
This removes warnings during `yarn install`.