### PR TITLE
Pin typescript to 5.x to satisfy the typescript peer dependency of the @typescript-eslint packages pulled in by eslint-plugin-jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint": "^9.0.0",
         "jest": "^30.0.0",
         "prettier": "^3.2.5",
-        "typescript": "6.0.3"
+        "typescript": "5.9.3"
       },
       "peerDependencies": {
         "eslint": "^9.0.0",
@@ -7244,9 +7244,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^9.0.0",
     "jest": "^30.0.0",
     "prettier": "^3.2.5",
-    "typescript": "6.0.3"
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "eslint": "^9.0.0",


### PR DESCRIPTION
This prevents a lot of npm warnings caused by mismatching peer dependencies.